### PR TITLE
Mongoose was giving a deprecation warning on server startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,12 +228,6 @@ function checkAdOwnership(req, res, next){
 
 app.listen(process.env.PORT,process.env.IP,function(){
     console.log("craigslist server has started");
-<<<<<<< HEAD
-<<<<<<< HEAD
 })
-=======
 })
->>>>>>> 253e608... Use the useMongoClient option on mongoose.connect() to stop the deprecation-warning at server start. http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client
-=======
 })
->>>>>>> 253e608... Use the useMongoClient option on mongoose.connect() to stop the deprecation-warning at server start. http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ passport.deserializeUser(User.deserializeUser());
 
 
 // mongoose.connect("mongodb://localhost/craigslist");
-mongoose.connect("mongodb://mndesai:marit5050@ds113606.mlab.com:13606/craigslist_clone", {useMongoClient: true})
+mongoose.connect("mongodb://mndesai:marit5050@ds113606.mlab.com:13606/craigslist_clone", {useMongoClient: true});
 // mongoose.connect(process.env.DATABASEURL);
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(methodOverride("_method"));
@@ -229,7 +229,11 @@ function checkAdOwnership(req, res, next){
 app.listen(process.env.PORT,process.env.IP,function(){
     console.log("craigslist server has started");
 <<<<<<< HEAD
+<<<<<<< HEAD
 })
+=======
+})
+>>>>>>> 253e608... Use the useMongoClient option on mongoose.connect() to stop the deprecation-warning at server start. http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client
 =======
 })
 >>>>>>> 253e608... Use the useMongoClient option on mongoose.connect() to stop the deprecation-warning at server start. http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ passport.deserializeUser(User.deserializeUser());
 
 
 // mongoose.connect("mongodb://localhost/craigslist");
-mongoose.connect("mongodb://mndesai:marit5050@ds113606.mlab.com:13606/craigslist_clone")
+mongoose.connect("mongodb://mndesai:marit5050@ds113606.mlab.com:13606/craigslist_clone", {useMongoClient: true})
 // mongoose.connect(process.env.DATABASEURL);
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(methodOverride("_method"));
@@ -228,4 +228,8 @@ function checkAdOwnership(req, res, next){
 
 app.listen(process.env.PORT,process.env.IP,function(){
     console.log("craigslist server has started");
+<<<<<<< HEAD
 })
+=======
+})
+>>>>>>> 253e608... Use the useMongoClient option on mongoose.connect() to stop the deprecation-warning at server start. http://mongoosejs.com/docs/4.x/docs/connections.html#use-mongo-client


### PR DESCRIPTION
Apparently there was some kind of deprecation on the mongoose client that caused a warning everytime the server started. Fixed that.